### PR TITLE
feat: implement email and password validation, refactor user store to use new types

### DIFF
--- a/.claude/instructions.md
+++ b/.claude/instructions.md
@@ -1,0 +1,5 @@
+# Claude Instructions
+
+Please read and follow all guidelines specified in `.github/copilot-instructions.md` for this project.
+
+All coding standards, design patterns, testing requirements, and implementation guidelines are defined in that file. Refer to it for every task and ensure compliance with those instructions.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,55 @@
+# Copilot Instructions
+
+## Code Quality & Design Patterns
+
+- Follow SOLID principles and Rust idioms (ownership, borrowing, lifetimes)
+- Prefer composition over inheritance, use traits for shared behavior
+- Implement error handling with custom error types that implement `Error`, `Display`, and where applicable, `From` traits
+- Use the type system to make invalid states unrepresentable
+- Apply the Repository pattern for data access, keeping database logic separate from business logic
+- Use dependency injection through constructor parameters or builder patterns
+- Prefer `Arc<dyn Trait>` over concrete types for better testability
+- Keep functions small and focused on a single responsibility
+- Use semantic types over primitives (e.g., `UserId(u32)` instead of bare `u32`)
+
+## Code Style
+
+- Write idiomatic Rust following the official style guide
+- Keep code DRY but prioritize clarity over cleverness
+- Add doc comments (`///`) for public APIs, include examples where helpful
+- Use descriptive variable names, avoid unnecessary abbreviations
+- Structure code with clear module boundaries and sensible visibility modifiers
+- Prefer iterators and functional approaches over manual loops where appropriate
+- Use `Result<T, E>` for fallible operations, avoid `unwrap()` except in tests
+
+## Testing & Validation
+
+- After implementing new functionality, automatically run:
+  1. `cargo check` to verify the code compiles
+  2. `cargo test` to run unit tests
+  3. `cargo clippy -- -W clippy::all` to check for common mistakes
+- Write unit tests for new functions, aim for testing behavior not implementation
+- Use `#[cfg(test)]` modules for test code
+- Create minimal test fixtures, avoid test interdependencies
+- Mock external dependencies using traits and test doubles
+- Include both happy path and error case tests
+
+## Implementation Guidelines
+
+- Start with the simplest working solution, then refactor if needed
+- Avoid premature optimization and over-engineering
+- Use standard library types before reaching for external crates
+- When using external crates, prefer well-maintained, widely-used options
+- Implement `Debug` for all types, `Clone` only when needed
+- Use `#[derive()]` for common traits when possible
+- Handle all `Result` and `Option` types explicitly, provide meaningful error messages
+- Prefer static dispatch (generics) over dynamic dispatch (trait objects) unless flexibility is needed
+
+## Async Code
+
+- Use `async`/`await` consistently, avoid blocking operations in async contexts
+- Prefer `tokio` for async runtime when needed
+- Use `Arc<Mutex<T>>` or `Arc<RwLock<T>>` for shared state in async code
+- Be mindful of cancellation safety in async operations
+
+Do not ask for permission to run tests or checks - just run them after implementing changes and include the results in your response.

--- a/auth-service/src/domain/data_stores.rs
+++ b/auth-service/src/domain/data_stores.rs
@@ -1,11 +1,11 @@
-use super::User;
+use super::{User, Email, Password};
 use crate::services::HashmapUserStore;
 
 #[async_trait::async_trait]
 pub trait UserStore {
     async fn add_user(&mut self, user: User) -> Result<(), UserStoreError>;
-    async fn get_user(&self, email: &str) -> Result<User, UserStoreError>;
-    async fn validate_user(&self, email: &str, password: &str) -> Result<(), UserStoreError>;
+    async fn get_user(&self, email: &Email) -> Result<User, UserStoreError>;
+    async fn validate_user(&self, email: &Email, password: &Password) -> Result<(), UserStoreError>;
 }
 
 #[async_trait::async_trait]
@@ -14,11 +14,11 @@ impl UserStore for HashmapUserStore {
         self.add_user(user)
     }
 
-    async fn get_user(&self, email: &str) -> Result<User, UserStoreError> {
+    async fn get_user(&self, email: &Email) -> Result<User, UserStoreError> {
         self.get_user(email)
     }
 
-    async fn validate_user(&self, email: &str, password: &str) -> Result<(), UserStoreError> {
+    async fn validate_user(&self, email: &Email, password: &Password) -> Result<(), UserStoreError> {
         self.validate_user(email, password)
     }
 }

--- a/auth-service/src/domain/email.rs
+++ b/auth-service/src/domain/email.rs
@@ -1,0 +1,91 @@
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub struct Email(String);
+
+#[derive(Debug, PartialEq)]
+pub enum EmailParseError {
+    InvalidFormat,
+    Empty,
+}
+
+impl Email {
+    pub fn parse(email: String) -> Result<Email, EmailParseError> {
+        if email.trim().is_empty() {
+            return Err(EmailParseError::Empty);
+        }
+
+        if !email.contains('@') || !email.contains('.') {
+            return Err(EmailParseError::InvalidFormat);
+        }
+
+        let parts: Vec<&str> = email.split('@').collect();
+        if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+            return Err(EmailParseError::InvalidFormat);
+        }
+
+        if !parts[1].contains('.') {
+            return Err(EmailParseError::InvalidFormat);
+        }
+
+        Ok(Email(email))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_email() {
+        let result = Email::parse("test@example.com".to_string());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0, "test@example.com");
+    }
+
+    #[test]
+    fn test_empty_email() {
+        let result = Email::parse("".to_string());
+        assert_eq!(result, Err(EmailParseError::Empty));
+    }
+
+    #[test]
+    fn test_whitespace_only_email() {
+        let result = Email::parse("   ".to_string());
+        assert_eq!(result, Err(EmailParseError::Empty));
+    }
+
+    #[test]
+    fn test_email_without_at_symbol() {
+        let result = Email::parse("testexample.com".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+
+    #[test]
+    fn test_email_without_dot() {
+        let result = Email::parse("test@example".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+
+    #[test]
+    fn test_email_with_empty_local_part() {
+        let result = Email::parse("@example.com".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+
+    #[test]
+    fn test_email_with_empty_domain() {
+        let result = Email::parse("test@".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+
+    #[test]
+    fn test_email_with_multiple_at_symbols() {
+        let result = Email::parse("test@example@com".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+
+    #[test]
+    fn test_email_domain_without_dot() {
+        let result = Email::parse("test@example".to_string());
+        assert_eq!(result, Err(EmailParseError::InvalidFormat));
+    }
+}

--- a/auth-service/src/domain/mod.rs
+++ b/auth-service/src/domain/mod.rs
@@ -1,7 +1,11 @@
 pub mod user;
 pub mod error;
 pub mod data_stores;
+pub mod email;
+pub mod password;
 
 pub use error::AuthAPIError;
 pub use user::User;
 pub use data_stores::UserStoreError;
+pub use email::{Email, EmailParseError};
+pub use password::{Password, PasswordParseError};

--- a/auth-service/src/domain/password.rs
+++ b/auth-service/src/domain/password.rs
@@ -1,0 +1,108 @@
+#[derive(Clone, Debug, PartialEq)]
+pub struct Password(String);
+
+#[derive(Debug, PartialEq)]
+pub enum PasswordParseError {
+    TooShort,
+    TooLong,
+    Empty,
+    MissingUppercase,
+    MissingLowercase,
+    MissingDigit,
+    MissingSpecialChar,
+}
+
+impl Password {
+    pub fn parse(password: String) -> Result<Password, PasswordParseError> {
+        if password.trim().is_empty() {
+            return Err(PasswordParseError::Empty);
+        }
+
+        if password.len() < 8 {
+            return Err(PasswordParseError::TooShort);
+        }
+
+        if password.len() > 128 {
+            return Err(PasswordParseError::TooLong);
+        }
+
+        if !password.chars().any(|c| c.is_ascii_uppercase()) {
+            return Err(PasswordParseError::MissingUppercase);
+        }
+
+        if !password.chars().any(|c| c.is_ascii_lowercase()) {
+            return Err(PasswordParseError::MissingLowercase);
+        }
+
+        if !password.chars().any(|c| c.is_ascii_digit()) {
+            return Err(PasswordParseError::MissingDigit);
+        }
+
+        if !password.chars().any(|c| "!@#$%^&*()_+-=[]{}|;:,.<>?".contains(c)) {
+            return Err(PasswordParseError::MissingSpecialChar);
+        }
+
+        Ok(Password(password))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_valid_password() {
+        let result = Password::parse("Password123!".to_string());
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().0, "Password123!");
+    }
+
+    #[test]
+    fn test_empty_password() {
+        let result = Password::parse("".to_string());
+        assert_eq!(result, Err(PasswordParseError::Empty));
+    }
+
+    #[test]
+    fn test_whitespace_only_password() {
+        let result = Password::parse("   ".to_string());
+        assert_eq!(result, Err(PasswordParseError::Empty));
+    }
+
+    #[test]
+    fn test_password_too_short() {
+        let result = Password::parse("Pass1!".to_string());
+        assert_eq!(result, Err(PasswordParseError::TooShort));
+    }
+
+    #[test]
+    fn test_password_too_long() {
+        let long_password = "P".repeat(120) + "assword1!";
+        let result = Password::parse(long_password);
+        assert_eq!(result, Err(PasswordParseError::TooLong));
+    }
+
+    #[test]
+    fn test_password_missing_uppercase() {
+        let result = Password::parse("password123!".to_string());
+        assert_eq!(result, Err(PasswordParseError::MissingUppercase));
+    }
+
+    #[test]
+    fn test_password_missing_lowercase() {
+        let result = Password::parse("PASSWORD123!".to_string());
+        assert_eq!(result, Err(PasswordParseError::MissingLowercase));
+    }
+
+    #[test]
+    fn test_password_missing_digit() {
+        let result = Password::parse("Password!".to_string());
+        assert_eq!(result, Err(PasswordParseError::MissingDigit));
+    }
+
+    #[test]
+    fn test_password_missing_special_char() {
+        let result = Password::parse("Password123".to_string());
+        assert_eq!(result, Err(PasswordParseError::MissingSpecialChar));
+    }
+}

--- a/auth-service/src/domain/user.rs
+++ b/auth-service/src/domain/user.rs
@@ -1,12 +1,14 @@
+use crate::domain::{Email, Password};
+
 #[derive(Clone, Debug, PartialEq)]
 pub struct User {
-    pub email: String,
-    password: String,
+    pub email: Email,
+    password: Password,
     requires_2fa: bool
 }
 
 impl User {
-    pub fn new(email: String, password: String, requires_2fa: bool) -> Self {
+    pub fn new(email: Email, password: Password, requires_2fa: bool) -> Self {
         Self {
             email,
             password,
@@ -14,7 +16,7 @@ impl User {
         }
     }
 
-    pub fn password(&self) -> &str {
+    pub fn password(&self) -> &Password {
         &self.password
     }
 }

--- a/auth-service/tests/api/signup.rs
+++ b/auth-service/tests/api/signup.rs
@@ -10,7 +10,7 @@ async fn should_return_422_if_malformed_input() {
 
     let test_cases = [
         serde_json::json!({
-            "password": "password123",
+            "password": "Password123!",
             "requires2FA": true
         }),
         serde_json::json!({
@@ -43,7 +43,7 @@ async fn should_return_201_if_valid_input() {
     let test_cases = [
         serde_json::json!({
             "email": random_email,
-            "password": "password123",
+            "password": "Password123!",
             "requires2FA": true
         }),
     ];
@@ -73,12 +73,12 @@ async fn should_return_400_if_invalid_input() {
     let input = [
         serde_json::json!({
             "email": "",
-            "password": "password123",
+            "password": "Password123!",
             "requires2FA": true
         }),
         serde_json::json!({
             "email": "no at email",
-            "password": "password123",
+            "password": "Password123!",
             "requires2FA": true
         }),
         serde_json::json!({
@@ -109,7 +109,7 @@ async fn should_return_409_if_email_already_exists() {
     let app = TestApp::new().await;
     let input = serde_json::json!({
         "email": "abc@email.com",
-        "password": "password123",
+        "password": "Password123!",
         "requires2FA": true
     });
     let response = app.post_signup(&input).await;


### PR DESCRIPTION
"Parse, don't validate" is a type-driven design principle which suggests that instead of merely validating input data against a set of conditions and then passing that data through the system assuming it meets those conditions, developers should transform (parse) this data into strongly typed data structures. 